### PR TITLE
default API credentials to empty strings for unauthenticated access

### DIFF
--- a/lib/coinbase/exchange/adapters/em_http.rb
+++ b/lib/coinbase/exchange/adapters/em_http.rb
@@ -2,7 +2,7 @@ module Coinbase
   module Exchange
     # EM-Http Adapter
     class EMHTTPClient < APIClient
-      def initialize(api_key, api_secret, api_pass, options = {})
+      def initialize(api_key = '', api_secret = '', api_pass = '', options = {})
         super(api_key, api_secret, api_pass, options)
       end
 

--- a/lib/coinbase/exchange/adapters/net_http.rb
+++ b/lib/coinbase/exchange/adapters/net_http.rb
@@ -2,7 +2,7 @@ module Coinbase
   module Exchange
     # Net-HTTP adapter
     class NetHTTPClient < APIClient
-      def initialize(api_key, api_secret, api_pass, options = {})
+      def initialize(api_key = '', api_secret = '', api_pass = '', options = {})
         super(api_key, api_secret, api_pass, options)
         @conn = Net::HTTP.new(@api_uri.host, @api_uri.port)
         @conn.use_ssl = true

--- a/lib/coinbase/exchange/api_client.rb
+++ b/lib/coinbase/exchange/api_client.rb
@@ -2,7 +2,7 @@ module Coinbase
   module Exchange
     # Net-http client for Coinbase Exchange API
     class APIClient
-      def initialize(api_key, api_secret, api_pass, options = {})
+      def initialize(api_key = '', api_secret = '', api_pass = '', options = {})
         @api_uri = URI.parse(options[:api_url] || "https://api.exchange.coinbase.com")
         @api_pass = api_pass
         @api_key = api_key


### PR DESCRIPTION
I would expect to be able to create a client without passing API credentials and have access to the public API endpoints.

This just sets the default argument values to empty strings.

```
 pry(main)> client = Coinbase::Exchange::AsyncClient.new
=> #<Coinbase::Exchange::AsyncClient:0x00000001c6ef48
 @api_key="",
 @api_pass="",
 @api_secret="",
 @api_uri=#<URI::HTTPS:0x00000001c6e278 URL:https://api.exchange.coinbase.com>,
 @default_product="BTC-USD">
```
