### PR TITLE
em-http-request should be a runtime dependency

### DIFF
--- a/coinbase-exchange.gemspec
+++ b/coinbase-exchange.gemspec
@@ -19,11 +19,11 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "bigdecimal"
   spec.add_dependency "faye-websocket"
+  spec.add_dependency "em-http-request"
 
   spec.add_development_dependency "bundler", "~> 1.8"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "webmock"
-  spec.add_development_dependency "em-http-request"
   spec.add_development_dependency "pry"
 end

--- a/lib/coinbase/exchange.rb
+++ b/lib/coinbase/exchange.rb
@@ -2,6 +2,7 @@ require "bigdecimal"
 require "json"
 require "uri"
 require "net/http"
+require "em-http-request"
 require "faye/websocket"
 
 require "coinbase/exchange/errors"


### PR DESCRIPTION
It was listed as a development dependency in the gemspec, this causes errors when using the AsyncClient.
