### PR TITLE
fix response_collections

### DIFF
--- a/lib/coinbase/exchange/api_client.rb
+++ b/lib/coinbase/exchange/api_client.rb
@@ -246,7 +246,7 @@ module Coinbase
 
       def response_collection(resp)
         out = resp.map { |item| APIObject.new(item) }
-        out.instance_eval { @response = resp.response }
+        out.instance_eval { @response = resp }
         add_metadata(out)
         out
       end


### PR DESCRIPTION
This fixes an error in #response_collections that caused #price_history to fail. I tested it manually and other methods that also return collections still appear to work.
