### PR TITLE
Incorrectly documented use of `orderbook` method.

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ p "Spot Rate: $ %.2f" % BigDecimal(resp['price'])
 The gem will automatically encode any additional parameters you pass to method calls.  For instance to get the full orderbook, you must explicitly set the level parameter to 3.
 
 ```ruby
-rest_api.orderbook('BTC-GBP', level: 3) do |resp|
+rest_api.orderbook(level: 3) do |resp|
   p "There are #{resp['bids'].count} open bids on the orderbook"
   p "There are #{resp['asks'].count} open asks on the orderbook"
 end


### PR DESCRIPTION
Docs would lead you to do:

``` ruby
client.orderbook(ORDER_BOOK_TYPE, level: ORDER_BOOK_LEVEL)" #=>
ArgumentError: wrong number of arguments (given 2, expected 0..1)
```

But instead, you need to initialize the client with ORDER_BOOK_TYPE (as is described in the docs):

``` ruby
Coinbase::Exchange::Client.new(
  ENV['CB_API_KEY'],
  ENV['CB_API_SECRET'],
  ENV['CB_PASSPHRASE'],
  product_id: ORDER_BOOK_TYPE
)
```
