### PR TITLE
Update api_client.rb

### DIFF
--- a/lib/coinbase/exchange/api_client.rb
+++ b/lib/coinbase/exchange/api_client.rb
@@ -3,7 +3,7 @@ module Coinbase
     # Net-http client for Coinbase Exchange API
     class APIClient
       def initialize(api_key = '', api_secret = '', api_pass = '', options = {})
-        @api_uri = URI.parse(options[:api_url] || "https://api.exchange.coinbase.com")
+        @api_uri = URI.parse(options[:api_url] || "https://api.gdax.com")
         @api_pass = api_pass
         @api_key = api_key
         @api_secret = api_secret


### PR DESCRIPTION
Updated the api_url default value to GDAX's new url: https://api.gdax.com