### PR TITLE
use tr instead of gsub

### DIFF
--- a/lib/coinbase/exchange/adapters/em_http.rb
+++ b/lib/coinbase/exchange/adapters/em_http.rb
@@ -70,7 +70,7 @@ module Coinbase
 
       def headers
         out = @response.response_header.map do |key, val|
-          [ key.upcase.gsub('_', '-'), val ]
+          [ key.upcase.tr('_', '-'), val ]
         end
         out.to_h
       end

--- a/lib/coinbase/exchange/adapters/net_http.rb
+++ b/lib/coinbase/exchange/adapters/net_http.rb
@@ -54,7 +54,7 @@ module Coinbase
 
       def headers
         out = @response.to_hash.map do |key, val|
-          [ key.upcase.gsub('_', '-'), val.count == 1 ? val.first : val ]
+          [ key.upcase.tr('_', '-'), val.count == 1 ? val.first : val ]
         end
         out.to_h
       end


### PR DESCRIPTION
For simple character replacement, tr is much faster than gsub.

https://gist.github.com/rafbm/9068f377f54b6b7a0915