### PR TITLE
correct typo in rest_api.orders example

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,7 +335,7 @@ end
 Downloads a list of all your orders.  Most likely, you'll only care about your open orders when using this.
 
 ```ruby
-rest_api.orders(status: open) do |resp|
+rest_api.orders(status: "open") do |resp|
   p "You have #{resp.count} open orders."
 end
 ```


### PR DESCRIPTION
The existing example gave me a syntax error. I made the correction and tested it.