### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,12 +384,12 @@ end
 
 ### Other
 
-**server_time**
+**server_epoch**
 
 Download the server time.
 
 ```ruby
-rest_api.server_time do |resp|
+rest_api.server_epoch do |resp|
   p "The time on the server is #{resp}"
 end
 ```


### PR DESCRIPTION
I think based on https://github.com/coinbase/coinbase-exchange-ruby/blob/master/lib/coinbase/exchange/api_client.rb#L13 the method `server_time` is a typo and should be `server_epoch`.