### PR TITLE
Removes the Bigdecimal gem requirement

### DIFF
--- a/coinbase-exchange.gemspec
+++ b/coinbase-exchange.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "bigdecimal"
   spec.add_dependency "faye-websocket"
   spec.add_dependency "em-http-request"
 

--- a/lib/coinbase/exchange.rb
+++ b/lib/coinbase/exchange.rb
@@ -1,4 +1,3 @@
-require "bigdecimal"
 require "json"
 require "uri"
 require "net/http"

--- a/lib/coinbase/exchange/api_client.rb
+++ b/lib/coinbase/exchange/api_client.rb
@@ -160,6 +160,21 @@ module Coinbase
       end
       alias_method :buy, :bid
 
+      def bid_market(funds, params = {})
+        params[:product_id] ||= @default_product
+        params[:funds] = funds
+        params[:side] = "buy"
+        params[:type] = "market"
+        
+        out = nil
+        post("/orders", params) do |resp|
+          out = response_object(resp)
+          yield(out, resp) if block_given?
+        end
+        out
+      end
+      alias_method :buy_market, :bid_market
+
       def ask(amt, price, params = {})
         params[:product_id] ||= @default_product
         params[:size] = amt
@@ -174,6 +189,21 @@ module Coinbase
         out
       end
       alias_method :sell, :ask
+
+      def ask_market(size, params = {})
+        params[:product_id] ||= @default_product
+        params[:size] = size
+        params[:side] = "sell"
+        params[:type] = "market"
+
+        out = nil
+        post("/orders", params) do |resp|
+          out = response_object(resp)
+          yield(out, resp) if block_given?
+        end
+        out
+      end
+      alias_method :sell_market, :ask_market
 
       def cancel(id)
         out = nil

--- a/lib/coinbase/exchange/version.rb
+++ b/lib/coinbase/exchange/version.rb
@@ -1,6 +1,6 @@
 module Coinbase
   # Gem version
   module Exchange
-    VERSION = "0.2.0"
+    VERSION = "0.2.1"
   end
 end


### PR DESCRIPTION
Since this is built into ruby, no reason to fetch the Gem version.